### PR TITLE
Fix pinned window state reset on reopen - Closes #6

### DIFF
--- a/Content/Modules/WindowManagement_essential/WindowManagement.cs
+++ b/Content/Modules/WindowManagement_essential/WindowManagement.cs
@@ -1326,13 +1326,13 @@ namespace MarySGameEngine.Modules.WindowManagement_essential
             else if (!_activeWindows.Contains(this))
             {
                 _activeWindows.Add(this);
-                if (_isPinned && !_pinnedWindows.Contains(this))
+                
+                // Reset pinned state when reopening a window
+                // This ensures that closed and reopened windows start unpinned
+                if (_isPinned)
                 {
-                    _pinnedWindows.Add(this);
-                    if (!_pinnedWindowsOrder.Contains(this))
-                    {
-                        _pinnedWindowsOrder.Add(this);
-                    }
+                    _engine.Log($"WindowManagement: Resetting pinned state for reopened window {_windowTitle}");
+                    _isPinned = false;
                 }
                 
                 // Ensure TaskBar has an icon for this window


### PR DESCRIPTION
## Fix for Issue #6: Reopened pinned window is still pinned

### Problem
When a pinned window was closed and reopened, it would remain pinned instead of resetting to unpinned state. This caused the pin icon to show as active when it should be default.

### Solution
Modified the `SetVisible` method in `WindowManagement.cs` to reset the pinned state (`_isPinned = false`) when a window is reopened. This ensures that:

1. Closed and reopened windows start unpinned
2. Pin icon shows the correct default state
3. Windows follow normal z-ordering after being reopened

### Changes Made
- Added logic in `SetVisible` method to reset `_isPinned` to `false` when reopening a window
- Added logging to track when pinned state is reset
- Removed the old logic that would re-add pinned windows to pinned lists on reopen

### Testing
- [x] Build successful with no errors
- [x] Fix addresses the exact issue described in #6
- [x] Maintains existing functionality for other window operations

This fix resolves the issue where reopened windows would incorrectly retain their pinned state